### PR TITLE
fix: correct "x86" spelling

### DIFF
--- a/pages/donate.vue
+++ b/pages/donate.vue
@@ -33,7 +33,7 @@
               <label
                 for="arch1"
                 class="ml-2"
-              >X86</label>
+              >x86</label>
             </div>
             <div class="flex items-center">
               <input

--- a/pages/products/download/x86.vue
+++ b/pages/products/download/x86.vue
@@ -57,7 +57,7 @@
 import desktops from '~/assets/desktops.json'
 
 useHead({
-  title: 'Download X86',
+  title: 'Download x86',
 })
 useServerSeoMeta({
   ogTitle: 'Manjaro Image Downloads',


### PR DESCRIPTION
Makes "x86" spelling use lower-case x as it's a brand name and should not be capitalized.